### PR TITLE
Adjust desktop popup notification size

### DIFF
--- a/components/welcome-notification-modal.tsx
+++ b/components/welcome-notification-modal.tsx
@@ -65,7 +65,7 @@ export function WelcomeNotificationModal({
       {/* Modal */}
       <div
         ref={modalRef}
-        className={`relative w-full max-w-md md:max-w-2xl lg:max-w-4xl mx-auto border-4 backdrop-blur-sm animate-in fade-in-0 zoom-in-95 duration-300 my-8 ${press2p.className}`}
+        className={`relative w-full max-w-md md:max-w-lg lg:max-w-2xl mx-auto border-4 backdrop-blur-sm animate-in fade-in-0 zoom-in-95 duration-300 my-8 ${press2p.className}`}
         style={{
           backgroundColor: PIXSELF_BRAND.colors.cloud.light,
           borderColor: PIXSELF_BRAND.colors.primary.navy,
@@ -104,7 +104,7 @@ export function WelcomeNotificationModal({
           {/* Image container */}
           <div className="flex justify-center">
             <div 
-              className="border-4 overflow-hidden w-full max-w-[300px] md:max-w-[500px] lg:max-w-[600px]"
+              className="border-4 overflow-hidden w-full max-w-[300px] md:max-w-[400px] lg:max-w-[450px]"
               style={{
                 borderColor: PIXSELF_BRAND.colors.primary.navy,
                 boxShadow: PIXSELF_BRAND.shadows.pixel,


### PR DESCRIPTION
Reduce the size of the welcome notification modal on desktop to make it less intrusive.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e76cf61-4691-4891-94ec-63de1327aa3d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2e76cf61-4691-4891-94ec-63de1327aa3d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

