### PR TITLE
Fix default-body-white asset rendering

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -732,6 +732,7 @@ export default function Page() {
                       onAssetSelect={(assetId) => onSelectAsset(activePart, assetId)}
                       isLoading={loading}
                       isMobile={false}
+                      parts={currentParts}
                     />
                   </div>
 
@@ -1044,6 +1045,7 @@ export default function Page() {
                     onAssetSelect={(assetId) => onSelectAsset(activePart, assetId)}
                     isLoading={loading}
                     isMobile={true}
+                    parts={currentParts}
                   />
                 </div>
 

--- a/components/asset-variant-grid.tsx
+++ b/components/asset-variant-grid.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import { PIXSELF_BRAND } from "@/config/pixself-brand"
-import { CHARACTER_PARTS } from "@/config/character-assets"
+import { CHARACTER_PARTS, type PartDefinition } from "@/config/character-assets"
 import type { PartKey } from "@/types/character"
 
 interface AssetVariantGridProps {
@@ -11,6 +11,7 @@ interface AssetVariantGridProps {
   onAssetSelect: (assetId: string) => void
   isLoading?: boolean
   isMobile?: boolean
+  parts?: PartDefinition[] // Add optional parts prop for dynamic assets
 }
 
 export function AssetVariantGrid({
@@ -19,10 +20,13 @@ export function AssetVariantGrid({
   onAssetSelect,
   isLoading = false,
   isMobile = false,
+  parts,
 }: AssetVariantGridProps) {
   const [, setPreviewAsset] = useState<string | null>(null)
 
-  const part = CHARACTER_PARTS().find((p) => p.key === activePart)
+  // Use provided parts or fallback to static parts
+  const allParts = parts || CHARACTER_PARTS()
+  const part = allParts.find((p) => p.key === activePart)
   if (!part) return null
 
   const assets = part.assets || []

--- a/public/test-dynamic-assets.html
+++ b/public/test-dynamic-assets.html
@@ -17,17 +17,29 @@
                     <h2>Asset Manifest:</h2>
                     <pre>${JSON.stringify(data, null, 2)}</pre>
                     
-                    <h2>Glasses Assets:</h2>
+                    <h2>Body Assets Test:</h2>
                     <ul>
-                        ${data.glasses.map(asset => `
+                        ${data.body.map(asset => `
                             <li>
                                 ${asset}
-                                <img src="/assets/character/accessories/glasses/${asset}" 
-                                     style="width:50px; height:50px; margin-left:10px;" 
-                                     onerror="this.src='data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTAiIGhlaWdodD0iNTAiIHZpZXdCb3g9IjAgMCA1MCA1MCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjUwIiBoZWlnaHQ9IjUwIiBmaWxsPSIjZmY2NjY2Ii8+Cjx0ZXh0IHg9IjI1IiB5PSIyNSIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZHk9Ii4zZW0iIGZvbnQtc2l6ZT0iMTIiIGZpbGw9IndoaXRlIj5FUlJPUjwvdGV4dD4KPHN2Zz4='; this.title='Failed to load';" />
+                                <img src="/assets/character/body/body/${asset}" 
+                                     style="width:100px; height:100px; margin-left:10px; image-rendering: pixelated;" 
+                                     onerror="this.src='data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTAiIGhlaWdodD0iNTAiIHZpZXdCb3g9IjAgMCA1MCA1MCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjUwIiBoZWlnaHQ9IjUwIiBmaWxsPSIjZmY2NjY2Ii8+Cjx0ZXh0IHg9IjI1IiB5PSIyNSIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZHk9Ii4zZW0iIGZvbnQtc2l6ZT0iMTIiIGZpbGw9IndoaXRlIj5FUlJPUjwvdGV4dD4KPHN2Zz4='; this.title='Failed to load';" 
+                                     onload="console.log('✅ Successfully loaded:', '${asset}');"
+                                     onerror="console.error('❌ Failed to load:', '${asset}');" />
                             </li>
                         `).join('')}
                     </ul>
+                    
+                    <h2>Specific Test: body-default-white.png</h2>
+                    <div style="border: 2px solid #333; padding: 10px; margin: 10px 0;">
+                        <p>Direct path test:</p>
+                        <img src="/assets/character/body/body/body-default-white.png" 
+                             style="width:200px; height:200px; image-rendering: pixelated; border: 1px solid red;" 
+                             onload="this.nextElementSibling.textContent = '✅ SUCCESS: body-default-white.png loaded!'; this.nextElementSibling.style.color='green';"
+                             onerror="this.nextElementSibling.textContent = '❌ ERROR: body-default-white.png failed to load!'; this.nextElementSibling.style.color='red';" />
+                        <p style="font-weight: bold;">Loading status...</p>
+                    </div>
                 `;
             } catch (error) {
                 document.getElementById('result').innerHTML = `


### PR DESCRIPTION
Update `AssetVariantGrid` to use dynamic asset parts, allowing all loaded assets to be displayed for selection.

---
<a href="https://cursor.com/background-agent?bcId=bc-6505ce03-89e8-496b-ad8a-4f446fe731a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6505ce03-89e8-496b-ad8a-4f446fe731a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

